### PR TITLE
<fix> train_best.pt 파일 명 변경, wandb 기록, trial default 값 지정, macs default 값 제거

### DIFF
--- a/baseline/optuna_train.py
+++ b/baseline/optuna_train.py
@@ -79,6 +79,7 @@ def train(
         criterion=criterion,
         optimizer=optimizer,
         scheduler=scheduler,
+        macs=macs,
         scaler=scaler,
         device=device,
         model_path=model_path,

--- a/baseline/src/trainer.py
+++ b/baseline/src/trainer.py
@@ -83,10 +83,10 @@ class TorchTrainer:
         criterion: nn.Module,
         optimizer: optim.Optimizer,
         scheduler,
+        macs,
         scaler = None,
         device: torch.device = "cpu",
-        model_path: str = None,        
-        macs = None,
+        model_path: str = None,
         verbose: int = 1,
         cur_time = -1,
         number = -1


### PR DESCRIPTION
- 파일 명 변경
  - optuna_train.py 실행 시 --weight 인자를 주면 **train_best_from_weight.pt** 로 저장
  - optuna_train.py 실행 시 --weight 인자를 주지 않으면 **train_best_from_scratch.pt** 로 저장
<br/>

- wandb 기록
  - src/trainer.py 에서 TorchTrainer class의 \_\_init\_\_() 함수의 매개변수로 **cur_time, number**(trial number) 추가.
    - cur_time, number를 인자로 주면 epoch 별로 **wandb에 log** 찍히도록 분기문 작성 (optuna_train.py 사용 시 필요해보여서 추가)
<br/>

- trial default 값 지정
  - src/trainer.py 에서 TorchTrainer class의 train() 함수의 trial 매개변수에 default 값을 None으로 설정
    - optuna_train.py 에서 학습할 경우 trial을 주지 못하기 때문에
    - trial 인자를 주지 않으면 report(), should_prouned() 실행하지 않도록 분기문 작성
<br/>

- macs default 값 삭제
  - src/trainer.py 에서 TorchTrainer class의 \_\_init\_\_() 함수의 매개변수인 macs 값에 default값 제거
  - LB 계산 시 필수적으로 필요하므로, macs 값을 주지 않을 경우 사전에 error raise